### PR TITLE
Fixed compilation on windows

### DIFF
--- a/pdfgen.c
+++ b/pdfgen.c
@@ -96,7 +96,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+#if !defined(WIN32)
 #include <unistd.h>
+#endif
 
 #include "pdfgen.h"
 
@@ -201,6 +204,22 @@ static int bin_offset[] = {
     (1 << (MIN_SHIFT + 14)) - 1 - MIN_OFFSET,
     (1 << (MIN_SHIFT + 15)) - 1 - MIN_OFFSET,
 };
+
+
+/*
+ * workaround for localtime_r on Windows
+ */
+#if defined(WIN32)
+struct tm *localtime_r(time_t *_clock, struct tm *_result)
+{
+  struct tm *p = localtime(_clock);
+
+  if (p)
+    *(_result) = *p;
+
+  return p;
+}
+#endif
 
 static inline int flexarray_get_bin(struct flexarray *flex, int index)
 {

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -11,6 +11,18 @@
 
 #include <stdint.h>
 
+
+#if defined(_MSC_VER)
+/*
+ * As stated Here: http://stackoverflow.com/questions/70013/how-to-detect-if-im-compiling-code-with-visual-studio-2008
+ * Visual Studio 2015 has better support for C99
+ * We need to use __inline for older version.
+ */
+#if _MSC_VER < 1900
+#define inline __inline
+#endif
+#endif // defined
+
 /**
  * @defgroup subsystem Simple PDF Generation
  * Allows for quick generation of simple PDF documents.
@@ -21,20 +33,20 @@
  * All coordinates are based on 0,0 being the bottom left of the page.
  * All colours are specified as a packed 32-bit value - see @ref PDF_RGB.
  * All text strings must be 7-bit ASCII only, not UTF-8 or other wide
- * 	character support.
+ *  character support.
  *
  * @par PDF library example:
  * @code
 #include "pdfgen.h"
  ...
 struct pdf_info info = {
-	 .creator = "My software",
-	 .producer = "My software",
-	 .title = "My document",
-	 .author = "My name",
-	 .subject = "My subject",
-	 .date = "Today"
-	 };
+   .creator = "My software",
+   .producer = "My software",
+   .title = "My document",
+   .author = "My name",
+   .subject = "My subject",
+   .date = "Today"
+   };
 struct pdf_doc *pdf = pdf_create(PDF_A4_WIDTH, PDF_A4_HEIGHT, &info);
 pdf_set_font(pdf, "Times-Roman");
 pdf_append_page(pdf);


### PR DESCRIPTION
Hello, I'm using this library for my programming language to generate report from the compilation process, and I noticed it does not work on Windows. 

I used the fix proposed here [https://bugs.webkit.org/show_bug.cgi?id=5311](https://bugs.webkit.org/show_bug.cgi?id=5311) Which implements `localtime_r` and removed `unistd` inclusion on Windows platform.

By the way, this is my first PR on github 😺 .

Cheers!