### PR TITLE
pdf_save: Added stdout support

### DIFF
--- a/pdfgen.c
+++ b/pdfgen.c
@@ -741,7 +741,9 @@ int pdf_save(struct pdf_doc *pdf, const char *filename)
     int xref_offset;
     int xref_count = 0;
 
-    if ((fp = fopen(filename, "wb")) == NULL)
+    if (filename == NULL)
+        fp = stdout;
+    else if ((fp = fopen(filename, "wb")) == NULL)
         return pdf_set_err(pdf, -errno, "Unable to open '%s': %s",
                            filename, strerror(errno));
 

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -210,6 +210,7 @@ int pdf_page_set_size(struct pdf_doc *pdf, struct pdf_object *page, int width, i
 
 /**
  * Save the given pdf document to the supplied filename
+ * If the filename is NULL, defaults to stdout
  */
 int pdf_save(struct pdf_doc *pdf, const char *filename);
 


### PR DESCRIPTION
This allows to output the pdf to stdout, when filename is not supplied to pdf_save