### PR TITLE
dstr: Try to use the stack for small strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ example-check: FORCE
 check-fuzz-%: tests/fuzz-% FORCE
 	./$< -verbosity=0 -max_total_time=60 -max_len=4096 -rss_limit_mb=1024
 
-fuzz-check: check-fuzz-ppm check-fuzz-jpg check-fuzz-header check-fuzz-text
+fuzz-check: check-fuzz-ppm check-fuzz-jpg check-fuzz-header check-fuzz-text check-fuzz-dstr
 
 format: FORCE
 	$(CLANG_FORMAT) -i pdfgen.c pdfgen.h tests/main.c tests/fuzz-ppm.c tests/fuzz-jpg.c tests/fuzz-header.c tests/fuzz-text.c

--- a/tests/fuzz-dstr.c
+++ b/tests/fuzz-dstr.c
@@ -1,0 +1,31 @@
+//#include <stdio.h>
+//#include <string.h>
+
+#include "pdfgen.c"
+
+int LLVMFuzzerTestOneInput(const char *data, int size)
+{
+    struct dstr str = INIT_DSTR;
+    int len;
+
+    if (size == 0)
+        return 0;
+
+    char *new_data = malloc(size);
+    if (!new_data)
+        return -1;
+    memcpy(new_data, data, size);
+
+    // Ensure it's null terminated
+    new_data[size - 1] = '\0';
+    len = strlen(new_data);
+
+    dstr_append(&str, new_data);
+    if (strcmp(dstr_data(&str), new_data) != 0) {
+        printf("Comparison failed:\n%s\n%s\n", dstr_data(&str), new_data);
+        return -1;
+    }
+    free(new_data);
+    dstr_free(&str);
+    return 0;
+}


### PR DESCRIPTION
This reduces the number of times we end up in malloc/free.
Most of the objects are fairly small.