### PR TITLE
dstr: Use it for PDF streams

### DIFF
--- a/pdfgen.c
+++ b/pdfgen.c
@@ -324,12 +324,6 @@ static inline void *flexarray_get(struct flexarray *flex, int index)
  * Simple dynamic string object. Tries to store a reasonable amount on the
  * stack before falling back to malloc once things get large
  */
-struct dstr {
-    char static_data[128];
-    char *data;
-    int alloc_len;
-    int used_len;
-};
 
 #define INIT_DSTR                                                            \
     (struct dstr)                                                            \
@@ -391,6 +385,15 @@ static int dstr_printf(struct dstr *str, const char *fmt, ...)
     va_end(ap);
     va_end(aq);
 
+    return len;
+}
+
+static int dstr_append_data(struct dstr *str, const void *extend, int len)
+{
+    if (dstr_ensure(str, str->used_len + len) < 0)
+        return -ENOMEM;
+    memcpy(dstr_data(str) + str->used_len, extend, len);
+    str->used_len += len;
     return len;
 }
 

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -949,6 +949,12 @@ static int dstr_ensure(struct dstr *str, int len)
         if (!str->data && str->used_len > 0)
             memcpy(new_data, str->static_data, str->used_len + 1);
         str->data = new_data;
+        if (str->used_len > 0 && str->alloc_len <= sizeof(str->static_data)) {
+            // We've grown beyond the stack buffer. Migrate the existing data
+            // across
+            memcpy(str->data, str->static_data, str->used_len + 1);
+            str->static_data[0] = '\0';
+        }
         str->alloc_len = new_len;
     }
     return 0;

--- a/tests/fuzz-dstr.c
+++ b/tests/fuzz-dstr.c
@@ -11,21 +11,29 @@ int LLVMFuzzerTestOneInput(const char *data, int size)
     if (size == 0)
         return 0;
 
-    char *new_data = malloc(size);
-    if (!new_data)
-        return -1;
-    memcpy(new_data, data, size);
+    if (data[0] & 0x1) {
+        char *new_data = malloc(size);
+        if (!new_data)
+            return -1;
+        memcpy(new_data, data, size);
 
-    // Ensure it's null terminated
-    new_data[size - 1] = '\0';
-    len = strlen(new_data);
+        // Ensure it's null terminated
+        new_data[size - 1] = '\0';
+        len = strlen(new_data);
 
-    dstr_append(&str, new_data);
-    if (strcmp(dstr_data(&str), new_data) != 0) {
-        printf("Comparison failed:\n%s\n%s\n", dstr_data(&str), new_data);
-        return -1;
+        dstr_append(&str, new_data);
+        if (strcmp(dstr_data(&str), new_data) != 0) {
+            printf("Comparison failed:\n%s\n%s\n", dstr_data(&str), new_data);
+            return -1;
+        }
+        free(new_data);
+    } else {
+        dstr_append_data(&str, data, size);
+        if (memcmp(dstr_data(&str), data, size) != 0) {
+            printf("Binary compare failed\n");
+            return -1;
+        }
     }
-    free(new_data);
     dstr_free(&str);
     return 0;
 }


### PR DESCRIPTION
This puts small objects directly into the pdf_object, avoiding an additional malloc.

This reduces the number of allocations & heap usage ie:
BEFORE:
==1491==   total heap usage: 6,282 allocs, 6,282 frees, 3,033,330 bytes allocated
AFTER:
==1499==   total heap usage: 3,198 allocs, 3,198 frees, 2,765,842 bytes allocated
