### PR TITLE
pdfgen: Add pdf_add_jpeg_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ testprog
 output.pdf
 output.txt
 docs/
+tests/penguin.c

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ check-fuzz-%: tests/fuzz-% FORCE
 fuzz-check: check-fuzz-ppm check-fuzz-jpg check-fuzz-header check-fuzz-text check-fuzz-dstr
 
 format: FORCE
-	$(CLANG_FORMAT) -i pdfgen.c pdfgen.h tests/main.c tests/fuzz-ppm.c tests/fuzz-jpg.c tests/fuzz-header.c tests/fuzz-text.c tests/penguin.c
+	$(CLANG_FORMAT) -i pdfgen.c pdfgen.h tests/main.c tests/fuzz-ppm.c tests/fuzz-jpg.c tests/fuzz-header.c tests/fuzz-text.c
 
 docs: FORCE
 	doxygen pdfgen.dox 2>&1 | tee doxygen.log

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -1984,8 +1984,8 @@ static pdf_object *pdf_add_raw_rgb24(struct pdf_doc *pdf, uint8_t *data,
 }
 
 /* See http://www.64lines.com/jpeg-width-height for details */
-static int jpeg_size(unsigned char *data, unsigned int data_size, int *width,
-                     int *height)
+static int jpeg_size(const unsigned char *data, unsigned int data_size,
+                     int *width, int *height)
 {
     int i = 0;
     if (i + 3 < data_size && data[i] == 0xFF && data[i + 1] == 0xD8 &&
@@ -2015,7 +2015,8 @@ static int jpeg_size(unsigned char *data, unsigned int data_size, int *width,
 }
 
 static pdf_object *pdf_add_raw_jpeg_data(struct pdf_doc *pdf,
-                                         unsigned char *jpeg_data, size_t len)
+                                         const unsigned char *jpeg_data,
+                                         size_t len)
 {
     struct pdf_object *obj;
     int width, height;
@@ -2198,7 +2199,7 @@ int pdf_add_jpeg(struct pdf_doc *pdf, struct pdf_object *page, int x, int y,
 
 int pdf_add_jpeg_data(struct pdf_doc *pdf, struct pdf_object *page, int x,
                       int y, int display_width, int display_height,
-                      unsigned char *jpeg_data, size_t len)
+                      const unsigned char *jpeg_data, size_t len)
 {
     struct pdf_object *obj;
 

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -2014,6 +2014,34 @@ static int jpeg_size(unsigned char *data, unsigned int data_size, int *width,
     return -1;
 }
 
+static pdf_object *pdf_add_raw_jpeg_data(struct pdf_doc *pdf,
+                                         unsigned char *jpeg_data, size_t len)
+{
+    struct pdf_object *obj;
+    int width, height;
+
+    if (jpeg_size(jpeg_data, len, &width, &height) < 0) {
+        pdf_set_err(pdf, -EINVAL, "Unable to determine jpeg width/height");
+        return NULL;
+    }
+
+    obj = pdf_add_object(pdf, OBJ_image);
+    if (!obj)
+        return NULL;
+    dstr_printf(&obj->stream,
+                "<<\r\n/Type /XObject\r\n/Name /Image%d\r\n"
+                "/Subtype /Image\r\n/ColorSpace /DeviceRGB\r\n"
+                "/Width %d\r\n/Height %d\r\n"
+                "/BitsPerComponent 8\r\n/Filter /DCTDecode\r\n"
+                "/Length %d\r\n>>stream\r\n",
+                flexarray_size(&pdf->objects), width, height, (int)len);
+    dstr_append_data(&obj->stream, jpeg_data, len);
+
+    dstr_printf(&obj->stream, "\r\nendstream\r\n");
+
+    return obj;
+}
+
 static pdf_object *pdf_add_raw_jpeg(struct pdf_doc *pdf,
                                     const char *jpeg_file)
 {
@@ -2022,7 +2050,6 @@ static pdf_object *pdf_add_raw_jpeg(struct pdf_doc *pdf,
     uint8_t *jpeg_data;
     FILE *fp;
     struct pdf_object *obj;
-    int width, height;
 
     if (stat(jpeg_file, &buf) < 0) {
         pdf_set_err(pdf, -errno, "Unable to access %s: %s", jpeg_file,
@@ -2053,27 +2080,13 @@ static pdf_object *pdf_add_raw_jpeg(struct pdf_doc *pdf,
     }
     fclose(fp);
 
-    if (jpeg_size(jpeg_data, len, &width, &height) < 0) {
+    obj = pdf_add_raw_jpeg_data(pdf, jpeg_data, len);
+    if (obj == NULL) {
         free(jpeg_data);
-        pdf_set_err(pdf, -EINVAL,
-                    "Unable to determine jpeg width/height from %s",
+        pdf_set_err(pdf, -EINVAL, "Unable to add jpeg data from %s",
                     jpeg_file);
         return NULL;
     }
-
-    obj = pdf_add_object(pdf, OBJ_image);
-    if (!obj)
-        return NULL;
-    dstr_printf(&obj->stream,
-                "<<\r\n/Type /XObject\r\n/Name /Image%d\r\n"
-                "/Subtype /Image\r\n/ColorSpace /DeviceRGB\r\n"
-                "/Width %d\r\n/Height %d\r\n"
-                "/BitsPerComponent 8\r\n/Filter /DCTDecode\r\n"
-                "/Length %d\r\n>>stream\r\n",
-                flexarray_size(&pdf->objects), width, height, (int)len);
-    dstr_append_data(&obj->stream, jpeg_data, len);
-
-    dstr_printf(&obj->stream, "\r\nendstream\r\n");
 
     free(jpeg_data);
 
@@ -2177,6 +2190,19 @@ int pdf_add_jpeg(struct pdf_doc *pdf, struct pdf_object *page, int x, int y,
     struct pdf_object *obj;
 
     obj = pdf_add_raw_jpeg(pdf, jpeg_file);
+    if (!obj)
+        return pdf->errval;
+
+    return pdf_add_image(pdf, page, obj, x, y, display_width, display_height);
+}
+
+int pdf_add_jpeg_data(struct pdf_doc *pdf, struct pdf_object *page, int x,
+                      int y, int display_width, int display_height,
+                      unsigned char *jpeg_data, size_t len)
+{
+    struct pdf_object *obj;
+
+    obj = pdf_add_raw_jpeg_data(pdf, jpeg_data, len);
     if (!obj)
         return pdf->errval;
 

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -466,6 +466,6 @@ int pdf_add_jpeg(struct pdf_doc *pdf, struct pdf_object *page, int x, int y,
  */
 int pdf_add_jpeg_data(struct pdf_doc *pdf, struct pdf_object *page, int x,
                       int y, int display_width, int display_height,
-                      unsigned char *jpeg_data, size_t len);
+                      const unsigned char *jpeg_data, size_t len);
 
 #endif // PDFGEN_H

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -453,4 +453,19 @@ int pdf_add_jpeg(struct pdf_doc *pdf, struct pdf_object *page, int x, int y,
                  int display_width, int display_height,
                  const char *jpeg_file);
 
+/**
+ * Add JPEG data as an image to the document
+ * @param pdf PDF document to add bookmark to
+ * @param page Page to add PPM to (NULL => most recently added page)
+ * @param x X offset to put JPEG at
+ * @param y Y offset to put JPEG at
+ * @param display_width Displayed width of image
+ * @param display_height Displayed height of image
+ * @param jpeg_data JPEG data to add
+ * @param len Length of JPEG data
+ */
+int pdf_add_jpeg_data(struct pdf_doc *pdf, struct pdf_object *page, int x,
+                      int y, int display_width, int display_height,
+                      unsigned char *jpeg_data, size_t len);
+
 #endif // PDFGEN_H

--- a/tests/main.c
+++ b/tests/main.c
@@ -3,6 +3,9 @@
 
 #include "pdfgen.h"
 
+extern unsigned char data_penguin_jpg[];
+extern unsigned int data_penguin_jpg_len;
+
 int main(int argc, char *argv[])
 {
     struct pdf_info info = {.creator = "My software",
@@ -69,7 +72,8 @@ int main(int argc, char *argv[])
                       PDF_RGB(0, 0, 0));
     pdf_add_ppm(pdf, NULL, 10, 10, 20, 30, "data/teapot.ppm");
 
-    pdf_add_jpeg(pdf, NULL, 100, 500, 50, 150, "data/penguin.jpg");
+    pdf_add_jpeg_data(pdf, NULL, 100, 500, 50, 150, data_penguin_jpg,
+                      data_penguin_jpg_len);
 
     pdf_add_barcode(pdf, NULL, PDF_BARCODE_128A, 50, 300, 200, 50, "Code128",
                     PDF_RGB(0, 0, 0));


### PR DESCRIPTION
This PR adds a function to add JPEG data directly from memory, which avoids a round-trip to the filesystem for requests that can be served entirely from memory.

I've tried to follow the conventions of PDFGen, including code style, automation, and testing. Let me know if I missed anything and I'll fix it.

I couldn't run the `valgrind` tests as I'm on macOS and `valgrind` is not available. Any problems, just say. 