### PR TITLE
Transparency

### DIFF
--- a/pdfgen.c
+++ b/pdfgen.c
@@ -429,15 +429,20 @@ static int pdf_set_err(struct pdf_doc *doc, int errval, const char *buffer,
     int len;
 
     va_start(ap, buffer);
-    len = vsnprintf(doc->errstr, sizeof(doc->errstr) - 2, buffer, ap);
+    len = vsnprintf(doc->errstr, sizeof(doc->errstr) - 1, buffer, ap);
     va_end(ap);
 
-    if (len >= sizeof(doc->errstr) - 2)
-        len = sizeof(doc->errstr) - 2;
+    if (len < 0) {
+        doc->errstr[0] = '\0';
+        return errval;
+    }
+
+    if (len >= sizeof(doc->errstr) - 1)
+        len = sizeof(doc->errstr) - 1;
 
     /* Make sure we're properly terminated */
-    if (doc->errstr[len] != '\n')
-        doc->errstr[len] = '\n';
+    if (len > 0 && doc->errstr[len - 1] != '\n')
+        doc->errstr[len - 1] = '\n';
     doc->errstr[len] = '\0';
     doc->errval = errval;
 

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -735,6 +735,12 @@ static int pdf_save_object(struct pdf_doc *pdf, FILE *fp, int index)
              font; font = font->next)
             fprintf(fp, "    /F%d %d 0 R\r\n", font->font.index, font->index);
         fprintf(fp, "  >>\r\n");
+        // We trim transparency to just 4-bits
+        fprintf(fp, "  /ExtGState <<\r\n");
+        for (int i = 0; i < 16; i++) {
+            fprintf(fp, "  /GS%d <</ca %f>>\r\n", i, (float)(15 - i) / 15);
+        }
+        fprintf(fp, "  >>\r\n");
 
         if (image) {
             fprintf(fp, "  /XObject <<");
@@ -1052,12 +1058,14 @@ static int pdf_add_text_spacing(struct pdf_doc *pdf, struct pdf_object *page,
     int ret;
     int len = text ? strlen(text) : 0;
     struct dstr str = INIT_DSTR;
+    int alpha = (colour >> 24) >> 4;
 
     /* Don't bother adding empty/null strings */
     if (!len)
         return 0;
 
     dstr_append(&str, "BT ");
+    dstr_printf(&str, "/GS%d gs ", alpha);
     dstr_printf(&str, "%d %d TD ", xoff, yoff);
     dstr_printf(&str, "/F%d %d Tf ", pdf->current_font->font.index, size);
     dstr_printf(&str, "%f %f %f rg ", PDF_RGB_R(colour), PDF_RGB_G(colour),

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -26,8 +26,8 @@
  *
  * @par PDF library example:
  * @code
-#include <stdio.h>
 #include "pdfgen.h"
+#include <stdio.h>
  ...
 struct pdf_info info = {
          .creator = "My software",
@@ -110,7 +110,8 @@ struct pdf_info {
     ((((r)&0xff) << 16) | (((g)&0xff) << 8) | (((b)&0xff)))
 
 #define PDF_ARGB(a, r, g, b)                                                 \
-    ((((a) & 0xff) << 24) | (((r)&0xff) << 16) | (((g)&0xff) << 8) | (((b)&0xff)))
+    ((((a)&0xff) << 24) | (((r)&0xff) << 16) | (((g)&0xff) << 8) |           \
+     (((b)&0xff)))
 
 /**
  * Utility macro to provide bright red

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -26,6 +26,7 @@
  *
  * @par PDF library example:
  * @code
+#include <stdio.h>
 #include "pdfgen.h"
  ...
 struct pdf_info info = {
@@ -39,7 +40,7 @@ struct pdf_info info = {
 struct pdf_doc *pdf = pdf_create(PDF_A4_WIDTH, PDF_A4_HEIGHT, &info);
 pdf_set_font(pdf, "Times-Roman");
 pdf_append_page(pdf);
-pdf_add_text(pdf, NULL, "This is text", 12, 50, 20);
+pdf_add_text(pdf, NULL, "This is text", 12, 50, 20, PDF_BLACK);
 pdf_add_line(pdf, NULL, 50, 24, 150, 24);
 pdf_save(pdf, "output.pdf");
 pdf_destroy(pdf);

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -109,6 +109,9 @@ struct pdf_info {
 #define PDF_RGB(r, g, b)                                                     \
     ((((r)&0xff) << 16) | (((g)&0xff) << 8) | (((b)&0xff)))
 
+#define PDF_ARGB(a, r, g, b)                                                 \
+    ((((a) & 0xff) << 24) | (((r)&0xff) << 16) | (((g)&0xff) << 8) | (((b)&0xff)))
+
 /**
  * Utility macro to provide bright red
  */

--- a/tests/main.c
+++ b/tests/main.c
@@ -90,6 +90,7 @@ int main(int argc, char *argv[])
     pdf_add_rectangle(pdf, NULL, 150, 150, 100, 100, 4, PDF_RGB(0, 0, 0xff));
     pdf_add_filled_rectangle(pdf, NULL, 150, 450, 100, 100, 4,
                              PDF_RGB(0, 0xff, 0));
+    pdf_add_text(pdf, NULL, "This should be transparent", 20, 160, 500, PDF_ARGB(0x80, 0, 0, 0));
     int p1X[] = {200, 200, 300, 300};
     int p1Y[] = {200, 300, 200, 300};
     pdf_add_polygon(pdf, NULL, p1X, p1Y, 4, 4, PDF_RGB(0xaa, 0xff, 0xee));

--- a/tests/main.c
+++ b/tests/main.c
@@ -90,7 +90,8 @@ int main(int argc, char *argv[])
     pdf_add_rectangle(pdf, NULL, 150, 150, 100, 100, 4, PDF_RGB(0, 0, 0xff));
     pdf_add_filled_rectangle(pdf, NULL, 150, 450, 100, 100, 4,
                              PDF_RGB(0, 0xff, 0));
-    pdf_add_text(pdf, NULL, "This should be transparent", 20, 160, 500, PDF_ARGB(0x80, 0, 0, 0));
+    pdf_add_text(pdf, NULL, "This should be transparent", 20, 160, 500,
+                 PDF_ARGB(0x80, 0, 0, 0));
     int p1X[] = {200, 200, 300, 300};
     int p1Y[] = {200, 300, 200, 300};
     pdf_add_polygon(pdf, NULL, p1X, p1Y, 4, 4, PDF_RGB(0xaa, 0xff, 0xee));


### PR DESCRIPTION
Add support for semi-transparent text
Currently limited to 16 fixed levels of transparency, even though we're working with an 8-bit alpha value.