### PR TITLE
circleci: Clean out build before running clang tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
                   fi
       - run:
           name: Test
-          command: scan-build-8 --status-bugs make check CLANG_FORMAT=clang-format-8
+          command: make clean && scan-build-8 --status-bugs make check CLANG_FORMAT=clang-format-8
       - run:
           name: Fuzz Test
           command: make fuzz-check CLANG=clang-8 CLANG_FORMAT=clang-format-8 -j4


### PR DESCRIPTION
This forces a full build, so clang-analyse finds it all