### PR TITLE
Add pseudo alignment for probing text wrapping height

### DIFF
--- a/pdfgen.c
+++ b/pdfgen.c
@@ -1598,8 +1598,10 @@ int pdf_add_text_wrap(struct pdf_doc *pdf, struct pdf_object *page,
                 break;
             }
 
-            pdf_add_text_spacing(pdf, page, line, size, xoff_align, yoff,
-                                 colour, char_spacing);
+            if (align != PDF_ALIGN_NO_WRITE) {
+                pdf_add_text_spacing(pdf, page, line, size, xoff_align, yoff,
+                                     colour, char_spacing);
+            }
 
             if (*end == ' ')
                 end++;

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -146,6 +146,8 @@ enum {
                        //!< available space
     PDF_ALIGN_JUSTIFY_ALL, //!< Like PDF_ALIGN_JUSTIFY, except even short
                            //!< lines will be fully justified
+    PDF_ALIGN_NO_WRITE, //!< Fake alignment for only checking wrap height with
+                        //!< no writes
 };
 
 /**


### PR DESCRIPTION
I found myself needing to check how much vertical real estate a wrapped text object would consume before writing anything, this was the simplest thing I could come up with (I didn't want to just copy/paste the function and yank out the parts which write content).