### PR TITLE
Fixed iOS build

### DIFF
--- a/pdfgen.c
+++ b/pdfgen.c
@@ -97,7 +97,7 @@
 typedef SSIZE_T ssize_t;
 #else
 #define _POSIX_SOURCE     /* For localtime_r */
-#define _XOPEN_SOURCE 500 /* for M_SQRT2 */
+#define _XOPEN_SOURCE 600 /* for M_SQRT2 */
 #include <sys/types.h>    /* for ssize_t */
 #endif
 


### PR DESCRIPTION
When `500 >= _XOPEN_SOURCE <= 599` vsnprintf and a few other standard C functions will give a compiler error like this: `implicit declaration library function 'vsnprintf' with type`. Bumping this number to 600 resolved errors for iOS: Apple Clang builds.