### PR TITLE
Fix up issues found by Trust-In-Soft

### DIFF
--- a/pdfgen.c
+++ b/pdfgen.c
@@ -111,6 +111,7 @@ typedef SSIZE_T ssize_t;
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -108,10 +108,10 @@ typedef SSIZE_T ssize_t;
 #include <inttypes.h>
 #include <math.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
@@ -1625,13 +1625,11 @@ int pdf_add_text_wrap(struct pdf_doc *pdf, struct pdf_object *page,
             case PDF_ALIGN_JUSTIFY:
                 if ((len - 1) > 0 && *end != '\r' && *end != '\n' &&
                     *end != '\0')
-                    char_spacing =
-                        ((double)(wrap_width - line_width)) / (len - 2);
+                    char_spacing = (wrap_width - line_width) / (len - 2);
                 break;
             case PDF_ALIGN_JUSTIFY_ALL:
                 if ((len - 1) > 0)
-                    char_spacing =
-                        ((double)(wrap_width - line_width)) / (len - 2);
+                    char_spacing = (wrap_width - line_width) / (len - 2);
                 break;
             }
 

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -355,13 +355,14 @@ static ssize_t dstr_ensure(struct dstr *str, size_t len)
     else if (str->alloc_len < len) {
         char *new_data;
         size_t new_len;
+        bool have_stack_data = !str->data;
 
         new_len = len + 4096;
         new_data = realloc(str->data, new_len);
         if (!new_data)
             return -ENOMEM;
         // If we move beyond the on-stack buffer, copy the old data out
-        if (!str->data && str->used_len > 0)
+        if (have_stack_data && str->used_len > 0)
             memcpy(new_data, str->static_data, str->used_len + 1);
         str->data = new_data;
         str->alloc_len = new_len;
@@ -1036,7 +1037,7 @@ static int pdf_add_stream(struct pdf_doc *pdf, struct pdf_object *page,
     if (!obj)
         return pdf->errval;
 
-    dstr_printf(&obj->stream, "<< /Length %zd >>stream\r\n", len);
+    dstr_printf(&obj->stream, "<< /Length %zu >>stream\r\n", len);
     dstr_append_data(&obj->stream, buffer, len);
     dstr_append(&obj->stream, "\r\nendstream\r\n");
 
@@ -2133,7 +2134,7 @@ static pdf_object *pdf_add_raw_rgb24(struct pdf_doc *pdf, const uint8_t *data,
     if (dstr_ensure(&str, len) < 0) {
         dstr_free(&str);
         pdf_set_err(pdf, -ENOMEM,
-                    "Unable to allocate %zd bytes memory for image", len);
+                    "Unable to allocate %zu bytes memory for image", len);
         return NULL;
     }
     for (int i = 0; i < width * height * 3; i++) {
@@ -2233,7 +2234,7 @@ static pdf_object *pdf_add_raw_jpeg(struct pdf_doc *pdf,
 
     jpeg_data = malloc(len);
     if (!jpeg_data) {
-        pdf_set_err(pdf, -errno, "Unable to allocate: %zd", len);
+        pdf_set_err(pdf, -errno, "Unable to allocate: %zu", len);
         fclose(fp);
         return NULL;
     }

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -134,7 +134,7 @@ struct pdf_path_operation {
  * (transparent)
  */
 #define PDF_ARGB(a, r, g, b)                                                 \
-    (uint32_t)((((a)&0xff) << 24) | (((r)&0xff) << 16) | (((g)&0xff) << 8) | \
+    (uint32_t)(((uint32_t)((a)&0xff) << 24) | (((r)&0xff) << 16) | (((g)&0xff) << 8) | \
                (((b)&0xff)))
 
 /*! Utility macro to provide bright red */
@@ -156,7 +156,7 @@ struct pdf_path_operation {
  * Utility macro to provide a transparent colour
  * This is used in some places for 'fill' colours, where no fill is required
  */
-#define PDF_TRANSPARENT (uint32_t)(0xff << 24)
+#define PDF_TRANSPARENT (uint32_t)(0xffu << 24)
 
 /**
  * Different alignment options for rendering text

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -134,8 +134,8 @@ struct pdf_path_operation {
  * (transparent)
  */
 #define PDF_ARGB(a, r, g, b)                                                 \
-    (uint32_t)(((uint32_t)((a)&0xff) << 24) | (((r)&0xff) << 16) | (((g)&0xff) << 8) | \
-               (((b)&0xff)))
+    (uint32_t)(((uint32_t)((a)&0xff) << 24) | (((r)&0xff) << 16) |           \
+               (((g)&0xff) << 8) | (((b)&0xff)))
 
 /*! Utility macro to provide bright red */
 #define PDF_RED PDF_RGB(0xff, 0, 0)


### PR DESCRIPTION
No-use of realloc argument after call
%zu not %zd for size_t
Shifting of signed values