### PR TITLE
Resize images and keep aspect ratio

### DIFF
--- a/pdfgen.c
+++ b/pdfgen.c
@@ -2289,8 +2289,8 @@ static pdf_object *pdf_add_raw_rgb24(struct pdf_doc *pdf, const uint8_t *data,
 }
 
 /* See http://www.videotechnology.com/jpeg/j1.html for details */
-static int jpeg_details(const uint8_t *data, size_t data_size, int *width,
-                        int *height, int *ncolours)
+static int jpeg_details(const uint8_t *data, size_t data_size,
+                        uint32_t *width, uint32_t *height, int *ncolours)
 {
     if (data_size < 4 || data[0] != 0xFF || data[1] != 0xD8)
         return -1;
@@ -2357,9 +2357,9 @@ static uint8_t *get_file(struct pdf_doc *pdf, const char *file_name,
 }
 
 static pdf_object *pdf_add_raw_jpeg_data(struct pdf_doc *pdf,
-                                         const uint8_t *jpeg_data,
-                                         size_t len, int *width_read,
-                                         int *height_read)
+                                         const uint8_t *jpeg_data, size_t len,
+                                         uint32_t *width_read,
+                                         uint32_t *height_read)
 {
     struct pdf_object *obj;
     int ncolours;
@@ -2393,23 +2393,30 @@ static pdf_object *pdf_add_raw_jpeg_data(struct pdf_doc *pdf,
  * Get the display dimensions of an image, respecting the images aspect ratio
  * if only one desired display dimension is defined.
  */
-static void get_img_display_dimensions(uint32_t img_width,
-                                       uint32_t img_height,
-                                       float *display_width,
-                                       float *display_height)
+static int get_img_display_dimensions(uint32_t img_width, uint32_t img_height,
+                                      float *display_width,
+                                      float *display_height)
 {
+    if (!display_height || !display_height) {
+        return -EINVAL;
+    }
+
     const float display_width_in = *display_width;
     const float display_height_in = *display_height;
-    // We can safely ignore checking the other dimension in the if statements,
-    // since the case where both display_width_in and display_height_in
-    // are <= 0 is already checked in pdf_add_image_data.
-    if (display_width_in <= 0) {
+
+    if ((display_width_in < 0 && display_height_in < 0) || img_width == 0 ||
+        img_height == 0) {
+        return -EINVAL;
+    }
+
+    if (display_width_in < 0) {
         // Set width, keeping aspect ratio
         *display_width = display_height_in * ((float)img_width / img_height);
-    } else if (display_height_in <= 0) {
+    } else if (display_height_in < 0) {
         // Set height, keeping aspect ratio
         *display_height = display_width_in * ((float)img_height / img_width);
     }
+    return 0;
 }
 
 static int pdf_add_image(struct pdf_doc *pdf, struct pdf_object *page,
@@ -2516,14 +2523,17 @@ static int pdf_add_jpeg_data(struct pdf_doc *pdf, struct pdf_object *page,
                              size_t len)
 {
     struct pdf_object *obj;
-    int img_width, img_height;
+    uint32_t img_width, img_height;
 
     obj = pdf_add_raw_jpeg_data(pdf, jpeg_data, len, &img_width, &img_height);
     if (!obj)
         return pdf->errval;
 
-    get_img_display_dimensions(img_width, img_height, &display_width,
-                               &display_height);
+    const int ret = get_img_display_dimensions(
+        img_width, img_height, &display_width, &display_height);
+    if (ret != 0) {
+        return ret;
+    }
     return pdf_add_image(pdf, page, obj, x, y, display_width, display_height);
 }
 
@@ -2537,8 +2547,11 @@ int pdf_add_rgb24(struct pdf_doc *pdf, struct pdf_object *page, float x,
     if (!obj)
         return pdf->errval;
 
-    get_img_display_dimensions(width, height, &display_width,
-                               &display_height);
+    const int ret = get_img_display_dimensions(width, height, &display_width,
+                                               &display_height);
+    if (ret != 0) {
+        return ret;
+    }
     return pdf_add_image(pdf, page, obj, x, y, display_width, display_height);
 }
 
@@ -2681,8 +2694,11 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
 
     free(final_data);
 
-    get_img_display_dimensions(info.width, info.height, &display_width,
-                               &display_height);
+    const int ret = get_img_display_dimensions(
+        info.width, info.height, &display_width, &display_height);
+    if (ret != 0) {
+        return ret;
+    }
     return pdf_add_image(pdf, page, obj, x, y, display_width, display_height);
 
 info_free:
@@ -2836,9 +2852,9 @@ int pdf_add_image_data(struct pdf_doc *pdf, struct pdf_object *page, float x,
                        float y, float display_width, float display_height,
                        const uint8_t *data, size_t len)
 {
-    if (display_width <= 0 && display_height <= 0) {
-        return pdf_set_err(
-            pdf, -EINVAL, "Cannot place image with display dimensions <= 0.");
+    if (display_width < 0 && display_height < 0) {
+        return pdf_set_err(pdf, -EINVAL,
+                           "Cannot place image with display dimensions < 0.");
     }
 
     // Try and determine which image format it is based on the content

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -2681,8 +2681,6 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
 
     free(final_data);
 
-    // pdf_page_set_size(pdf, page, info.width, info.height);
-    // return pdf_add_image(pdf, page, obj, x, y, info.width, info.height);
     get_img_display_dimensions(info.width, info.height, &display_width,
                                &display_height);
     return pdf_add_image(pdf, page, obj, x, y, display_width, display_height);

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -524,6 +524,10 @@ int pdf_add_barcode(struct pdf_doc *pdf, struct pdf_object *page, int code,
 /**
  * Add image data as an image to the document.
  * Image data must be one of: JPEG, PNG, PPM or BMP formats
+ * Passing 0 for either the display width or height will
+ * include the image but not render it visible.
+ * Passing a negative number either the display height or width will
+ * have the image be resized while keeping the original aspect ratio.
  * @param pdf PDF document to add image to
  * @param page Page to add image to (NULL => most recently added page)
  * @param x X offset to put image at
@@ -540,6 +544,10 @@ int pdf_add_image_data(struct pdf_doc *pdf, struct pdf_object *page, float x,
 
 /**
  * Add a raw 24 bit per pixel RGB buffer as an image to the document
+ * Passing 0 for either the display width or height will
+ * include the image but not render it visible.
+ * Passing a negative number either the display height or width will
+ * have the image be resized while keeping the original aspect ratio.
  * @param pdf PDF document to add image to
  * @param page Page to add image to (NULL => most recently added page)
  * @param x X offset to put image at
@@ -558,11 +566,15 @@ int pdf_add_rgb24(struct pdf_doc *pdf, struct pdf_object *page, float x,
 
 /**
  * Add an image file as an image to the document.
- * Support image formats: JPEG, PNG, BMP & PPM
+ * Passing 0 for either the display width or height will
+ * include the image but not render it visible.
+ * Passing a negative number either the display height or width will
+ * have the image be resized while keeping the original aspect ratio.
+ * Supports image formats: JPEG, PNG, BMP & PPM
  * @param pdf PDF document to add bookmark to
- * @param page Page to add BMP to (NULL => most recently added page)
- * @param x X offset to put BMP at
- * @param y Y offset to put BMP at
+ * @param page Page to add image to (NULL => most recently added page)
+ * @param x X offset to put image at
+ * @param y Y offset to put image at
  * @param display_width Displayed width of image
  * @param display_height Displayed height of image
  * @param image_filename Filename of image file to display


### PR DESCRIPTION
This PR somewhat stems from issue #95.

# Implemented Change
Any image added with a display width or height ≤ 0 will be dynamically resized to meet the given display height/width while keeping the aspect ratio intact.
This is done by setting the `display_width` or `display_height` parameter for `pdf_add_image`.
For that I created a dedicated function `get_img_display_dimensions`.

This is implemented for all image formats that are currently supported (png, bmp, jpeg, ppm).
I have tested this manually and it worked just fine, though I suggest you try this out yourself as well.

I also added a check if both the width and height are invalid, in which case an error is returned.

*One important note is that the external function signatures did not change, but their behaviour did.
Before, passing a width or height of ≤ 0 would result in the image being embedded into the pdf, but not be visible at all.
I would consider this a breaking change, there might someone who depends on the fact that the image isn't visible when passing 0.*

# Open Points
1. There are no checks for NaN or Infinity values for display dimensions. Maybe that's something to consider adding as well.
2. The image size in pixel is not always displayed in the same type.
PNG and BMP will handle it as `uint32_t`, while JPEG uses `int` and PPM `unsigned int`.
I think that's something that should be cleaned up, if you agree I'd just do it as part of this PR, or make a seperate one (whichever you prefer as maintainer).

# Note
Feel free to edit anything in the PR, I'm not a very experience C dev, and since I do a lot of C++ I might use a style that doesn't fit too well.

---
> I'll look into creating those features the next few days.

Well it's been two months since I said that, better late than never I guess.