### PR TITLE
Image processing rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 testprog
 output.pdf
 output.txt
+output.pdftk
 docs/
 tests/penguin.c

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -2847,7 +2847,6 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
         }
 
         pos += chunk_length; // add chunk length
-        // TODO consider actually checking the CRC, might be useful who knows
         pos += sizeof(uint32_t); // add CRC length
         if (pos > png_data_length) {
             pdf_set_err(pdf, -errno, "Wrong PNG format, chunks not found");

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -2756,13 +2756,7 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
     case PNG_COLOR_INDEXED:
         ncolours = 1;
         break;
-        // TODO Check if these color modes are supported
-        // case PNG_COLOR_GREYSCALE_A:
-        //     ncolours = 2;
-        //     break;
-        // case PNG_COLOR_RGBA:
-        //     ncolours = 4;
-        //     break;
+    // PNG_COLOR_RGBA and PNG_COLOR_GREYSCALE_A are unsupported
     default:
         pdf_set_err(pdf, -EINVAL, "PNG has unsupported color type: %d",
                     header->colorType);

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -2540,7 +2540,8 @@ static int parse_ppm_header(struct img_info *info, const uint8_t *data,
         snprintf(err_msg, err_msg_length, "Unable to find PPM size");
         return -EINVAL;
     }
-    info->specific_info.ppm.size = info->width * info->height * ncolors;
+    info->specific_info.ppm.size =
+        (uint64_t)info->width * info->height * ncolors;
     info->specific_info.ppm.data_begin_pos = pos;
 
     return 0;
@@ -2846,7 +2847,7 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
             goto free_buffers;
         }
 
-        pos += chunk_length; // add chunk length
+        pos += chunk_length;     // add chunk length
         pos += sizeof(uint32_t); // add CRC length
         if (pos > png_data_length) {
             pdf_set_err(pdf, -errno, "Wrong PNG format, chunks not found");

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -2896,7 +2896,7 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
     final_data = (uint8_t *)malloc(png_data_total_length + 1024 +
                                    dstr_len(&colour_space));
     if (!final_data) {
-        pdf_set_err(pdf, -ENOMEM, "Unable to allocate PNG data %d",
+        pdf_set_err(pdf, -ENOMEM, "Unable to allocate PNG data %zu",
                     png_data_total_length + 1024 + dstr_len(&colour_space));
         goto free_buffers;
     }
@@ -2912,7 +2912,7 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
                 "/BitsPerComponent %u\r\n/Filter /FlateDecode\r\n"
                 "/DecodeParms << /Predictor 15 /Colors %d "
                 "/BitsPerComponent %u /Columns %u >>\r\n"
-                "/Length %u\r\n>>stream\r\n",
+                "/Length %zu\r\n>>stream\r\n",
                 flexarray_size(&pdf->objects), dstr_data(&colour_space),
                 header->width, header->height, header->bitDepth, ncolours,
                 header->bitDepth, header->width, png_data_total_length);

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -193,6 +193,12 @@ static const uint8_t jpeg_signature[] = {0xff, 0xd8};
 static const uint8_t ppm_signature[] = {'P', '6'};
 static const uint8_t pgm_signature[] = {'P', '5'};
 
+// Special signatures for PNG chunks
+static const char png_chunk_header[] = "IHDR";
+static const char png_chunk_palette[] = "PLTE";
+static const char png_chunk_data[] = "IDAT";
+static const char png_chunk_end[] = "IEND";
+
 typedef struct pdf_object pdf_object;
 
 enum {
@@ -269,66 +275,17 @@ struct pdf_doc {
 };
 
 /**
- * Information about color type of PNG format
- * As defined by https://www.w3.org/TR/2003/REC-PNG-20031110/#6Colour-values
- */
-enum {
-    // Greyscale
-    PNG_COLOR_GREYSCALE = 0,
-    // Truecolour
-    PNG_COLOR_RGB = 2,
-    // Indexed-colour
-    PNG_COLOR_INDEXED = 3,
-    // Greyscale with alpha
-    PNG_COLOR_GREYSCALE_A = 4,
-    // Truecolour with alpha
-    PNG_COLOR_RGBA = 6,
-
-    PNG_COLOR_INVALID = 255
-};
-
-/**
  * Since we're casting random areas of memory to these, make sure
  * they're packed properly to match the image format requirements
  */
 #pragma pack(push, 1)
 struct png_chunk {
     uint32_t length;
+    // chunk type, see png_chunk_header, png_chunk_data, png_chunk_end
     char type[4];
 };
 
-struct png_header {
-    uint32_t width;
-    uint32_t height;
-    uint8_t bitdepth;
-    uint8_t colortype;
-    uint8_t deflate;
-    uint8_t filtering;
-    uint8_t interlace;
-};
-
-struct bmp_header {
-    uint32_t bfSize;
-    uint16_t bfReserved1; // ignore!
-    uint16_t bfReserved2; // ignore!
-    uint32_t bfOffBits;
-    uint32_t biSize;
-    int32_t biWidth;
-    int32_t biHeight;
-    uint16_t biPlanes; // ignore!
-    uint16_t biBitCount;
-    uint32_t biCompression;
-};
 #pragma pack(pop)
-
-struct png_info {
-    uint32_t length;
-    uint8_t bitdepth;
-    uint8_t color_type;
-    uint32_t width;
-    uint32_t height;
-    uint8_t *data;
-};
 
 // Simple data container to store a single 24 Bit RGB value, used for
 // processing PNG images
@@ -2383,30 +2340,6 @@ static struct pdf_object *pdf_add_raw_rgb24(struct pdf_doc *pdf,
     return obj;
 }
 
-/* See http://www.videotechnology.com/jpeg/j1.html for details */
-static int jpeg_details(const uint8_t *data, size_t data_size,
-                        uint32_t *width, uint32_t *height, int *ncolours)
-{
-    if (data_size < 4 || data[0] != 0xFF || data[1] != 0xD8)
-        return -1;
-    for (size_t i = 0; i < data_size - 3; i++) {
-        /* Search for SOFn marker and decode jpeg details */
-        if (data[i] == 0xff && (data[i + 1] & 0xf0) == 0xc0) {
-            int len = data[i + 2] * 256 + data[i + 3];
-            if (len >= 9 && i + len < data_size) {
-                if (height)
-                    *height = data[i + 5] * 256 + data[i + 6];
-                if (width)
-                    *width = data[i + 7] * 256 + data[i + 8];
-                if (ncolours)
-                    *ncolours = data[i + 9];
-                return 0;
-            }
-        }
-    }
-    return -1;
-}
-
 static uint8_t *get_file(struct pdf_doc *pdf, const char *file_name,
                          size_t *length)
 {
@@ -2451,31 +2384,25 @@ static uint8_t *get_file(struct pdf_doc *pdf, const char *file_name,
     return file_data;
 }
 
-static struct pdf_object *
-pdf_add_raw_jpeg_data(struct pdf_doc *pdf, const uint8_t *jpeg_data,
-                      size_t len, uint32_t *width_read, uint32_t *height_read)
+static struct pdf_object *pdf_add_raw_jpeg_data(struct pdf_doc *pdf,
+                                                const struct img_info *info,
+                                                const uint8_t *jpeg_data,
+                                                size_t len)
 {
-    struct pdf_object *obj;
-    int ncolours;
-
-    if (jpeg_details(jpeg_data, len, width_read, height_read, &ncolours) <
-        0) {
-        pdf_set_err(pdf, -EINVAL, "Unable to determine jpeg width/height");
-        return NULL;
-    }
-
-    obj = pdf_add_object(pdf, OBJ_image);
+    struct pdf_object *obj = pdf_add_object(pdf, OBJ_image);
     if (!obj)
         return NULL;
+
     dstr_printf(&obj->stream,
                 "<<\r\n/Type /XObject\r\n/Name /Image%d\r\n"
                 "/Subtype /Image\r\n/ColorSpace %s\r\n"
                 "/Width %d\r\n/Height %d\r\n"
                 "/BitsPerComponent 8\r\n/Filter /DCTDecode\r\n"
-                "/Length %d\r\n>>stream\r\n",
+                "/Length %zu\r\n>>stream\r\n",
                 flexarray_size(&pdf->objects),
-                ncolours == 1 ? "/DeviceGray" : "/DeviceRGB", *width_read,
-                *height_read, (int)len);
+                (info->specific_info.jpeg.ncolours == 1) ? "/DeviceGray"
+                                                         : "/DeviceRGB",
+                info->width, info->height, len);
     dstr_append_data(&obj->stream, jpeg_data, len);
 
     dstr_printf(&obj->stream, "\r\nendstream\r\n");
@@ -2572,80 +2499,135 @@ static size_t dgets(const uint8_t *data, size_t *pos, size_t len, char *line,
     return *pos;
 }
 
-static int pdf_add_ppm_data(struct pdf_doc *pdf, struct pdf_object *page,
-                            float x, float y, float display_width,
-                            float display_height, const uint8_t *ppm_data,
-                            size_t len)
+static int parse_ppm_header(struct img_info *info, const uint8_t *data,
+                            size_t length, char *err_msg,
+                            size_t err_msg_length)
 {
     char line[1024];
-    uint32_t width, height, size;
+    memset(line, '\0', sizeof(line));
     size_t pos = 0;
-    int bpp;
 
-    /* Load the PPM file */
-    if (!dgets(ppm_data, &pos, len, line, sizeof(line) - 1)) {
-        return pdf_set_err(pdf, -EINVAL, "Invalid PPM file");
+    // Load the PPM file
+    if (!dgets(data, &pos, length, line, sizeof(line) - 1)) {
+        snprintf(err_msg, err_msg_length, "Invalid PPM file");
+        return -EINVAL;
     }
 
-    /* We only support binary ppms */
+    // TODO reconsider this piece of code: determining color channels and
+    // whether we use text or binary should be seperate errors (if the format
+    // actually supports it...)
+
+    // Determine number of color channels (Also, we only support binary ppms)
     if (strncmp(line, "P6", 2) == 0) {
-        bpp = 3;
+        info->specific_info.ppm.ncolours = 3;
     } else if (strncmp(line, "P5", 2) == 0) {
-        bpp = 1;
+        info->specific_info.ppm.ncolours = 1;
     } else {
-        return pdf_set_err(pdf, -EINVAL, "Only binary PPM files supported");
+        snprintf(err_msg, err_msg_length, "Only binary PPM files supported");
+        return -EINVAL;
     }
 
-    /* Skip the header comments until we get to the dimensions info */
-    do {
-        if (!dgets(ppm_data, &pos, len, line, sizeof(line) - 1))
-            return pdf_set_err(pdf, -EINVAL, "Unable to find PPM size");
-        if (line[0] != '#')
-            break;
-    } while (1);
+    // Skip comments before header
+    while (line[0] == '#') {
+        if (!dgets(data, &pos, length, line, sizeof(line) - 1)) {
+            snprintf(err_msg, err_msg_length, "Unable to find PPM size");
+            return -EINVAL;
+        }
+    }
 
-    if (sscanf(line, "%u %u\n", &width, &height) != 2)
-        return pdf_set_err(pdf, -EINVAL, "Unable to find PPM size");
+    // Read image dimensions
+    if (sscanf(line, "%u %u\n", &(info->width), &(info->height)) != 2) {
+        snprintf(err_msg, err_msg_length, "Unable to find PPM size");
+        return -EINVAL;
+    }
+    info->specific_info.ppm.size =
+        info->width * info->height * info->specific_info.ppm.ncolours;
+    info->specific_info.ppm.data_begin_pos = pos;
+
+    return 0;
+}
+
+static int pdf_add_ppm_data(struct pdf_doc *pdf, struct pdf_object *page,
+                            float x, float y, float display_width,
+                            float display_height, const struct img_info *info,
+                            const uint8_t *ppm_data, size_t len)
+{
+    char line[1024];
+    // We start reading at the position delivered by parse_ppm_header,
+    // since we already parsed the header of the file there.
+    size_t pos = info->specific_info.ppm.data_begin_pos;
 
     /* Skip over the byte-size line */
     if (!dgets(ppm_data, &pos, len, line, sizeof(line) - 1))
         return pdf_set_err(pdf, -EINVAL, "No byte-size line in PPM file");
 
     /* Try and limit the memory usage to sane images */
-    if (width > 4096 || height > 4096) {
+    if (info->width > 4096 || info->height > 4096) {
         return pdf_set_err(pdf, -EINVAL,
-                           "Invalid width/height in PPM file: %ux%u", width,
-                           height);
+                           "Invalid width/height in PPM file: %ux%u",
+                           info->width, info->height);
     }
 
-    size = width * height * bpp;
-    if (size > len - pos) {
-        return pdf_set_err(pdf, -EINVAL, "Insufficient RGB data available");
+    if (info->specific_info.ppm.size > len - pos) {
+        return pdf_set_err(pdf, -EINVAL, "Insufficient image data available");
     }
 
-    if (bpp == 1)
+    switch (info->specific_info.ppm.ncolours) {
+    case 1: // todo enum stuff
         return pdf_add_grayscale8(pdf, page, x, y, display_width,
-                                  display_height, &ppm_data[pos], width,
-                                  height);
-    else
+                                  display_height, &ppm_data[pos], info->width,
+                                  info->height);
+        break;
+
+    case 3: // todo enum stuff
         return pdf_add_rgb24(pdf, page, x, y, display_width, display_height,
-                             &ppm_data[pos], width, height);
+                             &ppm_data[pos], info->width, info->height);
+        break;
+
+    default:
+        return pdf_set_err(pdf, -EINVAL,
+                           "Invalid number of color channels in ppm file: %i",
+                           info->specific_info.ppm.ncolours);
+        break;
+    }
+}
+
+static int parse_jpeg_header(struct img_info *info, const uint8_t *data,
+                             size_t length, char *err_msg,
+                             size_t err_msg_length)
+{
+    // See http://www.videotechnology.com/jpeg/j1.html for details
+    if (length >= 4 && data[0] == 0xFF && data[1] == 0xD8) {
+        for (size_t i = 0; i < length - 3; i++) {
+            /* Search for SOFn marker and decode jpeg details */
+            if (data[i] == 0xff && (data[i + 1] & 0xf0) == 0xc0) {
+                int len = data[i + 2] * 256 + data[i + 3];
+                if (len >= 9 && i + len < length) {
+                    info->height = data[i + 5] * 256 + data[i + 6];
+                    info->width = data[i + 7] * 256 + data[i + 8];
+                    info->specific_info.jpeg.ncolours = data[i + 9];
+                    return 0;
+                }
+            }
+        }
+    }
+    snprintf(err_msg, err_msg_length, "Error parsing JPEG header");
+    return -EINVAL;
 }
 
 static int pdf_add_jpeg_data(struct pdf_doc *pdf, struct pdf_object *page,
                              float x, float y, float display_width,
-                             float display_height, const uint8_t *jpeg_data,
-                             size_t len)
+                             float display_height, struct img_info *info,
+                             const uint8_t *jpeg_data, size_t len)
 {
     struct pdf_object *obj;
-    uint32_t img_width, img_height;
 
-    obj = pdf_add_raw_jpeg_data(pdf, jpeg_data, len, &img_width, &img_height);
+    obj = pdf_add_raw_jpeg_data(pdf, info, jpeg_data, len);
     if (!obj)
         return pdf->errval;
 
-    if (get_img_display_dimensions(pdf, img_width, img_height, &display_width,
-                                   &display_height)) {
+    if (get_img_display_dimensions(pdf, info->width, info->height,
+                                   &display_width, &display_height)) {
         return pdf->errval;
     }
     return pdf_add_image(pdf, page, obj, x, y, display_width, display_height);
@@ -2685,39 +2667,110 @@ int pdf_add_grayscale8(struct pdf_doc *pdf, struct pdf_object *page, float x,
     return pdf_add_image(pdf, page, obj, x, y, display_width, display_height);
 }
 
+static int parse_png_header(struct img_info *info, const uint8_t *data,
+                            size_t length, char *err_msg,
+                            size_t err_msg_length)
+{
+    if (length <= sizeof(png_signature)) {
+        snprintf(err_msg, err_msg_length, "PNG file too short");
+        return -EINVAL;
+    }
+
+    if (memcmp(data, png_signature, sizeof(png_signature))) {
+        snprintf(err_msg, err_msg_length, "File is not correct PNG file");
+        return -EINVAL;
+    }
+
+    // process first PNG chunk
+    uint32_t pos = sizeof(png_signature);
+    const struct png_chunk *chunk = (const struct png_chunk *)&data[pos];
+    pos += sizeof(struct png_chunk);
+    if (pos > length) {
+        snprintf(err_msg, err_msg_length, "PNG file too short");
+        return -EINVAL;
+    }
+    if (strncmp(chunk->type, png_chunk_header, 4) == 0) {
+        // header found, process width and height, check errors
+        struct png_header *header = &(info->specific_info.png);
+        memcpy(header, &data[pos], sizeof(struct png_header));
+
+        if (pos + sizeof(struct png_header) > length) {
+            snprintf(err_msg, err_msg_length, "PNG file too short");
+            return -EINVAL;
+        }
+        if (header->deflate != 0) {
+            snprintf(err_msg, err_msg_length, "Deflate wrong in PNG header");
+            return -EINVAL;
+        }
+        if (header->bitDepth == 0) {
+            snprintf(err_msg, err_msg_length, "PNG file has zero bit depth");
+            return -EINVAL;
+        }
+        // ensure the width and height values have the proper byte order
+        // and copy them into the info struct.
+        header->width = ntoh32(header->width);
+        header->height = ntoh32(header->height);
+        info->width = header->width;
+        info->height = header->height;
+        return 0;
+    }
+    snprintf(err_msg, err_msg_length, "Failed to read PNG file header");
+    return -EINVAL;
+}
+
 static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
                             float x, float y, float display_width,
-                            float display_height, const uint8_t *png_data,
-                            size_t len)
+                            float display_height,
+                            const struct img_info *img_info,
+                            const uint8_t *png_data, size_t png_data_length)
 {
-    const char png_chunk_header[] = "IHDR";
-    const char png_chunk_palette[] = "PLTE";
-    const char png_chunk_data[] = "IDAT";
-    const char png_chunk_end[] = "IEND";
-    struct pdf_object *obj;
+    // indicates if we return an error or add the img at the
+    // end of the function
+    bool success = false;
+
+    // string stream used for writing color space (and palette) info
+    // into the pdf
+    struct dstr colour_space = INIT_DSTR;
+
+    struct pdf_object *obj = NULL;
     uint8_t *final_data = NULL;
     int written = 0;
-    int chunk_index = 0;
     uint32_t pos;
-    uint8_t ncolours = 0;
-    struct png_info info = {
-        .length = 0,
-        .bitdepth = 0,
-        .color_type = PNG_COLOR_INVALID,
-        .width = 0,
-        .height = 0,
-        .data = NULL,
-    };
+    uint8_t *png_data_temp = NULL;
+    size_t png_data_total_length = 0;
+    uint8_t ncolours;
+
     // Stores palette information for indexed PNGs
     struct rgb_value *palette_buffer = NULL;
     size_t palette_buffer_length = 0;
-    struct dstr colour_space = INIT_DSTR;
 
-    if (len <= sizeof(png_signature))
-        return pdf_set_err(pdf, -EINVAL, "PNG file too short");
+    const struct png_header *header = &(img_info->specific_info.png);
 
-    if (memcmp(png_data, png_signature, sizeof(png_signature)))
-        return pdf_set_err(pdf, -EINVAL, "File is not correct PNG file");
+    // Father info from png header
+    switch (header->colorType) {
+    case PNG_COLOR_GREYSCALE:
+        ncolours = 1;
+        break;
+    case PNG_COLOR_RGB:
+        ncolours = 3;
+        break;
+    case PNG_COLOR_INDEXED:
+        ncolours = 1;
+        break;
+        // TODO Check if these color modes are supported
+        // case PNG_COLOR_GREYSCALE_A:
+        //     ncolours = 2;
+        //     break;
+        // case PNG_COLOR_RGBA:
+        //     ncolours = 4;
+        //     break;
+    default:
+        pdf_set_err(pdf, -EINVAL, "PNG has unsupported color type: %d",
+                    header->colorType);
+        goto free_buffers;
+        break;
+    }
+
     /* process PNG chunks */
     pos = sizeof(png_signature);
 
@@ -2726,72 +2779,28 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
 
         chunk = (const struct png_chunk *)&png_data[pos];
         pos += sizeof(struct png_chunk);
-        if (pos > len) {
+        if (pos > png_data_length) {
             pdf_set_err(pdf, -EINVAL, "PNG file too short");
-            goto info_free;
+            goto free_buffers;
         }
         const uint32_t chunk_length = ntoh32(chunk->length);
         if (strncmp(chunk->type, png_chunk_header, 4) == 0) {
-            if (chunk_index != 0) {
-                pdf_set_err(
-                    pdf, -EINVAL,
-                    "PNG format error: header chunk is not the first chunk");
-                goto info_free;
-            }
-            /* header found, process width and height, check errors */
-            const struct png_header *header =
-                (const struct png_header *)&png_data[pos];
-            if (pos + sizeof(struct png_header) > len) {
-                pdf_set_err(pdf, -EINVAL, "PNG file too short");
-                goto info_free;
-            }
-            if (header->deflate != 0) {
-                pdf_set_err(pdf, -EINVAL, "Deflate wrong in PNG header");
-                goto info_free;
-            }
-            // Determine the number of colour channels
-            switch (header->colortype) {
-            case PNG_COLOR_GREYSCALE:
-                ncolours = 1;
-                break;
-            case PNG_COLOR_RGB:
-                ncolours = 3;
-                break;
-            case PNG_COLOR_INDEXED:
-                ncolours = 1;
-                break;
-
-            case PNG_COLOR_GREYSCALE_A:
-            case PNG_COLOR_RGBA:
-                pdf_set_err(pdf, -EINVAL,
-                            "PNGs with an alpha channel are not supported");
-                goto info_free;
-                break;
-
-            default:
-                pdf_set_err(pdf, -EINVAL, "Unknown PNG color type %d",
-                            header->colortype);
-                goto info_free;
-                break;
-            }
-            info.color_type = header->colortype;
-            info.width = ntoh32(header->width);
-            info.height = ntoh32(header->height);
-            info.bitdepth = header->bitdepth;
+            // Ignoring the header, since it was parsed
+            // before calling this function.
         } else if (strncmp(chunk->type, png_chunk_palette, 4) == 0) {
             // Palette chunk
-            if (info.color_type == PNG_COLOR_INDEXED) {
+            if (header->colorType == PNG_COLOR_INDEXED) {
+                // palette chunk is needed for indexed images
                 if (palette_buffer) {
                     pdf_set_err(pdf, -EINVAL,
-                                "PNG contains multiple palettes");
-                    goto info_free;
+                                "PNG contains multiple palette chunks");
+                    goto free_buffers;
                 }
-                // palette chunk is needed for indexed images
                 if (chunk_length % 3 != 0) {
                     pdf_set_err(pdf, -EINVAL,
                                 "PNG format error: palette chunk length is "
                                 "not divisbly by 3!");
-                    goto info_free;
+                    goto free_buffers;
                 }
                 palette_buffer_length = (size_t)(chunk_length / 3);
                 palette_buffer = (struct rgb_value *)malloc(
@@ -2802,7 +2811,7 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
                                 "palette (%zu bytes)",
                                 palette_buffer_length *
                                     sizeof(struct rgb_value));
-                    goto info_free;
+                    goto free_buffers;
                 }
                 for (size_t i = 0; i < palette_buffer_length; i++) {
                     size_t offset = (i * 3) + pos;
@@ -2810,60 +2819,56 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
                     palette_buffer[i].green = png_data[offset + 1];
                     palette_buffer[i].blue = png_data[offset + 2];
                 }
-            } else if (info.color_type == PNG_COLOR_RGB ||
-                       info.color_type == PNG_COLOR_RGBA) {
+            } else if (header->colorType == PNG_COLOR_RGB ||
+                       header->colorType == PNG_COLOR_RGBA) {
                 // palette chunk is optional for RGB(A) images
                 // but we do not process them
             } else {
                 pdf_set_err(pdf, -EINVAL,
                             "Unexpected palette chunk for color type %d",
-                            info.color_type);
-                goto info_free;
+                            header->colorType);
+                goto free_buffers;
             }
         } else if (strncmp(chunk->type, png_chunk_data, 4) == 0) {
-            if (chunk_length > 0 && chunk_length < len - pos) {
-                uint8_t *data =
-                    (uint8_t *)realloc(info.data, info.length + chunk_length);
+            if (chunk_length > 0 && chunk_length < png_data_length - pos) {
+                uint8_t *data = (uint8_t *)realloc(
+                    png_data_temp, png_data_total_length + chunk_length);
+                // (uint8_t *)realloc(info.data, info.length + chunk_length);
                 if (!data) {
                     pdf_set_err(pdf, -ENOMEM, "No memory for PNG data");
-                    goto info_free;
+                    goto free_buffers;
                 }
-                info.data = data;
-                memcpy(&info.data[info.length], &png_data[pos], chunk_length);
-                info.length += chunk_length;
+                png_data_temp = data;
+                memcpy(&png_data_temp[png_data_total_length], &png_data[pos],
+                       chunk_length);
+                png_data_total_length += chunk_length;
             }
         } else if (strncmp(chunk->type, png_chunk_end, 4) == 0) {
             /* end of file, exit */
             break;
         }
 
-        if (chunk_length >= len) {
+        if (chunk_length >= png_data_length) {
             pdf_set_err(pdf, -EINVAL, "PNG chunk length larger than file");
-            goto info_free;
+            goto free_buffers;
         }
 
-        pos += chunk_length;     // add chunk length
+        pos += chunk_length; // add chunk length
+        // TODO consider actually checking the CRC, might be useful who knows
         pos += sizeof(uint32_t); // add CRC length
-        if (pos > len) {
+        if (pos > png_data_length) {
             pdf_set_err(pdf, -errno, "Wrong PNG format, chunks not found");
-            goto info_free;
+            goto free_buffers;
         }
-        chunk_index++;
-    }
-    /* if no length was found */
-    if (info.length == 0 || info.bitdepth == 0) {
-        pdf_set_err(pdf, -EINVAL, "PNG file has zero length/bitdepth");
-        goto info_free;
-    }
-    /* if no color type was found (header chunk missing?) */
-    if (info.color_type == PNG_COLOR_INVALID || ncolours == 0) {
-        pdf_set_err(
-            pdf, -EINVAL,
-            "PNG file missing color type, is the header chunk missing?");
-        goto info_free;
     }
 
-    switch (info.color_type) {
+    /* if no length was found */
+    if (png_data_total_length == 0) {
+        pdf_set_err(pdf, -EINVAL, "PNG file has zero length");
+        goto free_buffers;
+    }
+
+    switch (header->colorType) {
     case PNG_COLOR_GREYSCALE:
         dstr_append(&colour_space, "/DeviceGray");
         break;
@@ -2891,91 +2896,103 @@ static int pdf_add_png_data(struct pdf_doc *pdf, struct pdf_object *page,
     default:
         pdf_set_err(pdf, -EINVAL,
                     "Cannot map PNG color type %d to PDF color space",
-                    info.color_type);
-        goto info_free;
+                    header->colorType);
+        goto free_buffers;
         break;
     }
 
-    if (palette_buffer) {
-        free(palette_buffer);
-        palette_buffer = NULL;
-    }
-
-    final_data =
-        (uint8_t *)malloc(info.length + 1024 + dstr_len(&colour_space));
+    final_data = (uint8_t *)malloc(png_data_total_length + 1024 +
+                                   dstr_len(&colour_space));
     if (!final_data) {
         pdf_set_err(pdf, -ENOMEM, "Unable to allocate PNG data %d",
-                    info.length + 1024);
-        goto info_free;
+                    png_data_total_length + 1024 + dstr_len(&colour_space));
+        goto free_buffers;
     }
 
     // Write image information to PDF
-    written = sprintf((char *)final_data,
-                      "<<\r\n/Type /XObject\r\n/Name /Image%d\r\n"
-                      "/Subtype /Image\r\n"
-                      "/ColorSpace %s\r\n"
-                      "/Width %u\r\n/Height %u\r\n"
-                      "/Interpolate true\r\n"
-                      "/BitsPerComponent %u\r\n/Filter /FlateDecode\r\n"
-                      "/DecodeParms << /Predictor 15 /Colors %d "
-                      "/BitsPerComponent %u /Columns %u >>\r\n"
-                      "/Length %u\r\n>>stream\r\n",
-                      flexarray_size(&pdf->objects), dstr_data(&colour_space),
-                      info.width, info.height, info.bitdepth, ncolours,
-                      info.bitdepth, info.width, info.length);
-    dstr_free(&colour_space);
+    written =
+        sprintf((char *)final_data,
+                "<<\r\n/Type /XObject\r\n/Name /Image%d\r\n"
+                "/Subtype /Image\r\n"
+                "/ColorSpace %s\r\n"
+                "/Width %u\r\n/Height %u\r\n"
+                "/Interpolate true\r\n"
+                "/BitsPerComponent %u\r\n/Filter /FlateDecode\r\n"
+                "/DecodeParms << /Predictor 15 /Colors %d "
+                "/BitsPerComponent %u /Columns %u >>\r\n"
+                "/Length %u\r\n>>stream\r\n",
+                flexarray_size(&pdf->objects), dstr_data(&colour_space),
+                header->width, header->height, header->bitDepth, ncolours,
+                header->bitDepth, header->width, png_data_total_length);
 
-    memcpy(&final_data[written], info.data, info.length);
-    free(info.data);
-    info.data = NULL;
-    written += info.length;
+    memcpy(&final_data[written], png_data, png_data_total_length);
+    written += png_data_total_length;
     written += sprintf((char *)&final_data[written], "\r\nendstream\r\n");
 
     obj = pdf_add_object(pdf, OBJ_image);
     if (!obj) {
-        free(final_data);
-        return pdf_get_errval(pdf);
+        goto free_buffers;
     }
 
     dstr_append_data(&obj->stream, final_data, written);
 
-    free(final_data);
-
-    if (get_img_display_dimensions(pdf, info.width, info.height,
+    if (get_img_display_dimensions(pdf, header->width, header->height,
                                    &display_width, &display_height)) {
-        return pdf->errval;
+        goto free_buffers;
     }
-    return pdf_add_image(pdf, page, obj, x, y, display_width, display_height);
+    success = true;
 
-info_free:
-    if (info.data)
-        free(info.data);
+free_buffers:
     if (final_data)
         free(final_data);
     if (palette_buffer)
         free(palette_buffer);
-    return pdf->errval;
+    if (png_data_temp)
+        free(png_data_temp);
+    dstr_free(&colour_space);
+
+    if (success)
+        return pdf_add_image(pdf, page, obj, x, y, display_width,
+                             display_height);
+    else
+        return pdf->errval;
+}
+
+static int parse_bmp_header(struct img_info *info, const uint8_t *data,
+                            size_t data_length, char *err_msg,
+                            size_t err_msg_length)
+{
+    if (data_length < sizeof(bmp_signature) + sizeof(struct bmp_header)) {
+        snprintf(err_msg, err_msg_length, "File is too short");
+        return -EINVAL;
+    }
+
+    if (memcmp(data, bmp_signature, sizeof(bmp_signature))) {
+        snprintf(err_msg, err_msg_length, "File is not correct BMP file");
+        return -EINVAL;
+    }
+    memcpy(&(info->specific_info.bmp), data, sizeof(bmp_signature));
+    info->width = info->specific_info.bmp.biWidth;
+    // biHeight might be negative (positive indicates vertically mirrored
+    // lines)
+    info->height = abs(info->specific_info.bmp.biHeight);
+    return 0;
 }
 
 static int pdf_add_bmp_data(struct pdf_doc *pdf, struct pdf_object *page,
                             float x, float y, float display_width,
-                            float display_height, const uint8_t *data,
-                            const size_t len)
+                            float display_height, const struct img_info *info,
+                            const uint8_t *data, const size_t len)
 {
-    const struct bmp_header *header;
+    const struct bmp_header *header = &(info->specific_info.bmp);
     uint8_t *bmp_data = NULL;
     uint8_t row_padding;
-    uint32_t width, height, bpp;
-    bool flip = true;
-    int retval;
+    uint32_t bpp;
     size_t data_len;
+    int retval;
+    const uint32_t width = info->width;
+    const uint32_t height = info->height;
 
-    if (len < sizeof(bmp_signature) + sizeof(struct bmp_header))
-        return pdf_set_err(pdf, -EINVAL, "File is too short");
-
-    if (memcmp(data, bmp_signature, sizeof(bmp_signature)))
-        return pdf_set_err(pdf, -EINVAL, "File is not correct BMP file");
-    header = (const struct bmp_header *)&data[sizeof(bmp_signature)];
     if (header->bfSize != len)
         return pdf_set_err(pdf, -EINVAL,
                            "BMP file seems to have wrong length");
@@ -2995,13 +3012,6 @@ static int pdf_add_bmp_data(struct pdf_doc *pdf, struct pdf_object *page,
         return pdf_set_err(pdf, -EINVAL, "Unsupported BMP bitdepth: %d",
                            header->biBitCount);
     bpp = header->biBitCount / 8;
-    width = header->biWidth;
-    if (header->biHeight < 0) {
-        flip = false;
-        height = -header->biHeight;
-    } else {
-        height = header->biHeight;
-    }
     /* BMP rows are 4-bytes padded! */
     row_padding = (width * bpp) & 3;
     data_len = (size_t)width * (size_t)height * 3;
@@ -3045,9 +3055,8 @@ static int pdf_add_bmp_data(struct pdf_doc *pdf, struct pdf_object *page,
         return pdf_set_err(pdf, -EINVAL, "Unsupported BMP bitdepth: %d",
                            header->biBitCount);
     }
-    if (flip) {
-        /* BMP has vertically mirrored representation of lines, so swap them
-         */
+    if (header->biHeight >= 0) {
+        // BMP has vertically mirrored representation of lines, so swap them
         uint8_t *line = (uint8_t *)malloc(width * 3);
         if (!line) {
             free(bmp_data);
@@ -3071,16 +3080,7 @@ static int pdf_add_bmp_data(struct pdf_doc *pdf, struct pdf_object *page,
     return retval;
 }
 
-enum {
-    IMAGE_PNG,
-    IMAGE_JPG,
-    IMAGE_PPM,
-    IMAGE_BMP,
-
-    IMAGE_UNKNOWN
-};
-
-static int header_to_image(const uint8_t *data, size_t length)
+static int determine_image_format(const uint8_t *data, size_t length)
 {
     if (length >= sizeof(png_signature) &&
         memcmp(data, png_signature, sizeof(png_signature)) == 0)
@@ -3101,29 +3101,68 @@ static int header_to_image(const uint8_t *data, size_t length)
     return IMAGE_UNKNOWN;
 }
 
+int parse_image_header(struct img_info *info, const uint8_t *data,
+                       size_t length, char *err_msg, size_t err_msg_length)
+
+{
+    const int image_format = determine_image_format(data, length);
+    info->image_format = image_format;
+    switch (image_format) {
+    case IMAGE_PNG:
+        return parse_png_header(info, data, length, err_msg, err_msg_length);
+    case IMAGE_BMP:
+        return parse_bmp_header(info, data, length, err_msg, err_msg_length);
+    case IMAGE_JPG:
+        return parse_jpeg_header(info, data, length, err_msg, err_msg_length);
+    case IMAGE_PPM:
+        return parse_ppm_header(info, data, length, err_msg, err_msg_length);
+
+    case IMAGE_UNKNOWN:
+    default:
+        snprintf(err_msg, err_msg_length, "Unknown file format");
+        return -EINVAL;
+    }
+}
+
 int pdf_add_image_data(struct pdf_doc *pdf, struct pdf_object *page, float x,
                        float y, float display_width, float display_height,
                        const uint8_t *data, size_t len)
 {
+    struct img_info info = {
+        .width = 0,
+        .height = 0,
+        .image_format = IMAGE_UNKNOWN,
+    };
+    char err_msg[sizeof(pdf->errstr)];
+    memset(err_msg, '\0', sizeof(pdf->errstr));
+
+    const int ret =
+        parse_image_header(&info, data, len, err_msg, sizeof(pdf->errstr));
+    if (ret) {
+        pdf_set_err(pdf, ret, err_msg);
+        return ret;
+    }
+
     // Try and determine which image format it is based on the content
-    switch (header_to_image(data, len)) {
+    switch (info.image_format) {
     case IMAGE_PNG:
         return pdf_add_png_data(pdf, page, x, y, display_width,
-                                display_height, data, len);
+                                display_height, &info, data, len);
     case IMAGE_BMP:
         return pdf_add_bmp_data(pdf, page, x, y, display_width,
-                                display_height, data, len);
+                                display_height, &info, data, len);
     case IMAGE_JPG:
         return pdf_add_jpeg_data(pdf, page, x, y, display_width,
-                                 display_height, data, len);
+                                 display_height, &info, data, len);
     case IMAGE_PPM:
         return pdf_add_ppm_data(pdf, page, x, y, display_width,
-                                display_height, data, len);
+                                display_height, &info, data, len);
 
+    // This case should be caught in parse_image_header, but is checked
+    // here again for safety
     case IMAGE_UNKNOWN:
     default:
-        return pdf_set_err(pdf, -EINVAL,
-                           "Unable to determine image format for");
+        return pdf_set_err(pdf, -EINVAL, "Unable to determine image format");
     }
 }
 

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -2346,8 +2346,9 @@ static pdf_object *pdf_add_raw_grayscale8(struct pdf_doc *pdf,
     return obj;
 }
 
-static pdf_object *pdf_add_raw_rgb24(struct pdf_doc *pdf, const uint8_t *data,
-                                     uint32_t width, uint32_t height)
+static struct pdf_object *pdf_add_raw_rgb24(struct pdf_doc *pdf,
+                                            const uint8_t *data,
+                                            uint32_t width, uint32_t height)
 {
     struct pdf_object *obj;
     size_t len;
@@ -2450,10 +2451,9 @@ static uint8_t *get_file(struct pdf_doc *pdf, const char *file_name,
     return file_data;
 }
 
-static pdf_object *pdf_add_raw_jpeg_data(struct pdf_doc *pdf,
-                                         const uint8_t *jpeg_data, size_t len,
-                                         uint32_t *width_read,
-                                         uint32_t *height_read)
+static struct pdf_object *
+pdf_add_raw_jpeg_data(struct pdf_doc *pdf, const uint8_t *jpeg_data,
+                      size_t len, uint32_t *width_read, uint32_t *height_read)
 {
     struct pdf_object *obj;
     int ncolours;

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -134,11 +134,17 @@ struct jpeg_header {
     int ncolours;
 };
 
+enum /* PPM color spaces */ {
+    // binary ppm with RGB colors (magic number P5)
+    PPM_BINARY_COLOR_RGB,
+    // binary ppm with grayscale colors (magic number P6)
+    PPM_BINARY_COLOR_GRAY
+};
+
 struct ppm_header {
     uint64_t size;         // Indicate the size of the image data
     size_t data_begin_pos; // position in the data where the image starts
-    int ncolours;          // number of color channels (1=grayscale,3=rgb)
-    // TODO consider making ncolours an enum for both ppm and jpeg
+    int color_space;        // PPM color space
 };
 
 union format_specific_img_info {


### PR DESCRIPTION
I have returned, with quite a lot of changes:

* Introduce a general purpose `img_info` structure, that contains a image's header (making use of a union).
* Split the `add_<format>_data` functions up:
  * a `parse_<format>_header` which writes relevant info into a `struct img_info`
  * the `pdf_add_<format>_data` which relies on the passed `img_info` and doesn't parse the img header itself.
* Introduce `parse_image_header` (in the .h file), to be able to obtain image information before adding the image, this can be used to address #95.
* renamed `header_to_image` to `determine_image_format`

_Disclaimer:_ I started writing this a few months ago and only picked it up now. 
I probably have introduced a bug here or there, especially the memory management in `pdf_add_png_data` should be closer inspected.

I ran `tests.sh` and the two generated PDFs looked the exact same to me.
Diffing the two pdfs showed that only the `/CreationDate` in line 10 and the `/ID` in line 22916 have changed.

There are also a handful of todo comments that I intend to address before merging, but I decided to create the PR already so you can take a look at the changes.