### PR TITLE
Add functionality to add link annotations

### DIFF
--- a/pdfgen.c
+++ b/pdfgen.c
@@ -272,7 +272,8 @@ struct pdf_object {
             float urx;
             float ury;
             struct pdf_object *target_page; /* Target page */
-            float target_y;                 /* Target location */
+            float target_x;                 /* Target location */
+            float target_y;
         } link;
     };
 };
@@ -1105,12 +1106,12 @@ static int pdf_save_object(struct pdf_doc *pdf, FILE *fp, int index)
                 "  /Type /Annot\r\n"
                 "  /Subtype /Link\r\n"
                 "  /Rect [%f %f %f %f]\r\n"
-                "  /Dest [%u 0 R /XYZ 0 %f null]\r\n"
+                "  /Dest [%u 0 R /XYZ %f %f null]\r\n"
                 "  /Border [0 0 0]\r\n"
                 ">>\r\n",
                 object->link.llx, object->link.lly, object->link.urx,
                 object->link.ury, object->link.target_page->index,
-                object->link.target_y);
+                object->link.target_x, object->link.target_y);
         break;
     }
 
@@ -1280,7 +1281,8 @@ int pdf_add_bookmark(struct pdf_doc *pdf, struct pdf_object *page, int parent,
 
 int pdf_add_link(struct pdf_doc *pdf, struct pdf_object *page, float x,
                  float y, float width, float height,
-                 struct pdf_object *target_page, float target_y)
+                 struct pdf_object *target_page, float target_x,
+                 float target_y)
 {
     struct pdf_object *obj;
 
@@ -1300,6 +1302,7 @@ int pdf_add_link(struct pdf_doc *pdf, struct pdf_object *page, float x,
     }
 
     obj->link.target_page = target_page;
+    obj->link.target_x = target_x;
     obj->link.target_y = target_y;
     obj->link.llx = x;
     obj->link.lly = y;

--- a/pdfgen.c
+++ b/pdfgen.c
@@ -218,6 +218,7 @@ enum {
     OBJ_catalog,
     OBJ_pages,
     OBJ_image,
+    OBJ_link,
 
     OBJ_count,
 };
@@ -257,12 +258,22 @@ struct pdf_object {
             float width;
             float height;
             struct flexarray children;
+            struct flexarray annotations;
         } page;
         struct pdf_info *info;
         struct {
             char name[64];
             int index;
         } font;
+        struct {
+            struct pdf_object *page; /* Page containing link */
+            float llx;               /* Clickable rectangle */
+            float lly;
+            float urx;
+            float ury;
+            struct pdf_object *target_page; /* Target page */
+            float target_y;                 /* Target location */
+        } link;
     };
 };
 
@@ -629,6 +640,7 @@ static void pdf_object_destroy(struct pdf_object *object)
         break;
     case OBJ_page:
         flexarray_clear(&object->page.children);
+        flexarray_clear(&object->page.annotations);
         break;
     case OBJ_info:
         free(object->info);
@@ -945,16 +957,27 @@ static int pdf_save_object(struct pdf_doc *pdf, FILE *fp, int index)
                 fprintf(fp, "/Image%d %d 0 R ", image->index, image->index);
             fprintf(fp, ">>\r\n");
         }
-
         fprintf(fp, ">>\r\n");
+
         fprintf(fp, "/Contents [\r\n");
         for (int i = 0; i < flexarray_size(&object->page.children); i++) {
             struct pdf_object *child =
                 (struct pdf_object *)flexarray_get(&object->page.children, i);
             fprintf(fp, "%d 0 R\r\n", child->index);
         }
-
         fprintf(fp, "]\r\n");
+
+        if (flexarray_size(&object->page.annotations)) {
+            fprintf(fp, "/Annots [\r\n");
+            for (int i = 0; i < flexarray_size(&object->page.annotations);
+                 i++) {
+                struct pdf_object *child = (struct pdf_object *)flexarray_get(
+                    &object->page.annotations, i);
+                fprintf(fp, "%d 0 R\r\n", child->index);
+            }
+            fprintf(fp, "]\r\n");
+        }
+
         fprintf(fp, ">>\r\n");
         break;
     }
@@ -1073,6 +1096,21 @@ static int pdf_save_object(struct pdf_doc *pdf, FILE *fp, int index)
                 "/Pages %d 0 R\r\n"
                 ">>\r\n",
                 pages->index);
+        break;
+    }
+
+    case OBJ_link: {
+        fprintf(fp,
+                "<<\r\n"
+                "  /Type /Annot\r\n"
+                "  /Subtype /Link\r\n"
+                "  /Rect [%f %f %f %f]\r\n"
+                "  /Dest [%u 0 R /XYZ 0 %f null]\r\n"
+                "  /Border [0 0 0]\r\n"
+                ">>\r\n",
+                object->link.llx, object->link.lly, object->link.urx,
+                object->link.ury, object->link.target_page->index,
+                object->link.target_y);
         break;
     }
 
@@ -1236,6 +1274,38 @@ int pdf_add_bookmark(struct pdf_doc *pdf, struct pdf_object *page, int parent,
         obj->bookmark.parent = parent_obj;
         flexarray_append(&parent_obj->bookmark.children, obj);
     }
+
+    return obj->index;
+}
+
+int pdf_add_link(struct pdf_doc *pdf, struct pdf_object *page, float x,
+                 float y, float width, float height,
+                 struct pdf_object *target_page, float target_y)
+{
+    struct pdf_object *obj;
+
+    if (!page)
+        page = pdf_find_last_object(pdf, OBJ_page);
+
+    if (!page)
+        return pdf_set_err(pdf, -EINVAL,
+                           "Unable to add link, no pages available");
+
+    if (!target_page)
+        return pdf_set_err(pdf, -EINVAL, "Unable to link, no target page");
+
+    obj = pdf_add_object(pdf, OBJ_link);
+    if (!obj) {
+        return pdf->errval;
+    }
+
+    obj->link.target_page = target_page;
+    obj->link.target_y = target_y;
+    obj->link.llx = x;
+    obj->link.lly = y;
+    obj->link.urx = x + width;
+    obj->link.ury = y + height;
+    flexarray_append(&page->page.annotations, obj);
 
     return obj->index;
 }
@@ -1712,6 +1782,8 @@ static const uint16_t *find_font_widths(const char *font_name)
 int pdf_get_font_text_width(struct pdf_doc *pdf, const char *font_name,
                             const char *text, float size, float *text_width)
 {
+    if (!font_name)
+        font_name = pdf->current_font->font.name;
     const uint16_t *widths = find_font_widths(font_name);
 
     if (!widths)

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -627,6 +627,23 @@ int pdf_add_bookmark(struct pdf_doc *pdf, struct pdf_object *page, int parent,
                      const char *name);
 
 /**
+ * Add a link annotation to the document
+ * @param pdf PDF document to add link to
+ * @param page Page that holds the clickable rectangle
+               (or NULL for the most recently added page)
+ * @param x X coordinate of bottom LHS corner of clickable rectangle
+ * @param y Y coordinate of bottom LHS corner of clickable rectangle
+ * @param width width of clickable rectangle
+ * @param height height of clickable rectangle
+ * @param target_page Page to jump to for link
+ * @param target_y Y coordinate to position at the top of the view
+ * @return < 0 on failure, new bookmark id on success
+ */
+int pdf_add_link(struct pdf_doc *pdf, struct pdf_object *page, float x,
+                 float y, float width, float height,
+                 struct pdf_object *target_page, float target_y);
+
+/**
  * List of different barcode encodings that are supported
  */
 enum {

--- a/pdfgen.h
+++ b/pdfgen.h
@@ -636,12 +636,14 @@ int pdf_add_bookmark(struct pdf_doc *pdf, struct pdf_object *page, int parent,
  * @param width width of clickable rectangle
  * @param height height of clickable rectangle
  * @param target_page Page to jump to for link
+ * @param target_x X coordinate to position at the left of the view
  * @param target_y Y coordinate to position at the top of the view
  * @return < 0 on failure, new bookmark id on success
  */
 int pdf_add_link(struct pdf_doc *pdf, struct pdf_object *page, float x,
                  float y, float width, float height,
-                 struct pdf_object *target_page, float target_y);
+                 struct pdf_object *target_page, float target_x,
+                 float target_y);
 
 /**
  * List of different barcode encodings that are supported

--- a/tests/main.c
+++ b/tests/main.c
@@ -268,7 +268,7 @@ int main(int argc, char *argv[])
                  PDF_RGB(0xff, 0, 0));
     if (pdf_get_font_text_width(pdf, NULL, "This is an A3 landscape page", 10,
                                 &width) == 0) {
-        pdf_add_link(pdf, NULL, 20, 30, width, 10, first_page,
+        pdf_add_link(pdf, NULL, 20, 30, width, 10, first_page, 0,
                      pdf_page_height(first_page) / 2);
     }
     pdf_add_rgb24(pdf, NULL, 72, 72, 288, 144, data_rgb, 16, 8);

--- a/tests/main.c
+++ b/tests/main.c
@@ -17,6 +17,7 @@ int main(int argc, char *argv[])
                             .author = "My name",
                             .subject = "My subject"};
     struct pdf_doc *pdf = pdf_create(PDF_A4_WIDTH, PDF_A4_HEIGHT, &info);
+    struct pdf_object *first_page;
     int i;
     float height, width;
     int bm;
@@ -75,7 +76,7 @@ int main(int argc, char *argv[])
     /* From now on, we shouldn't see any errors */
 
     pdf_set_font(pdf, "Times-BoldItalic");
-    pdf_append_page(pdf);
+    first_page = pdf_append_page(pdf);
 
     pdf_add_text_wrap(
         pdf, NULL,
@@ -265,6 +266,11 @@ int main(int argc, char *argv[])
 
     pdf_add_text(pdf, NULL, "This is an A3 landscape page", 10, 20, 30,
                  PDF_RGB(0xff, 0, 0));
+    if (pdf_get_font_text_width(pdf, NULL, "This is an A3 landscape page", 10,
+                                &width) == 0) {
+        pdf_add_link(pdf, NULL, 20, 30, width, 10, first_page,
+                     pdf_page_height(first_page) / 2);
+    }
     pdf_add_rgb24(pdf, NULL, 72, 72, 288, 144, data_rgb, 16, 8);
 
     pdf_save(pdf, "output.pdf");


### PR DESCRIPTION
Link annotations are useful for creating constructs like Table of
Contents or Indexes.

This adds a new function pdf_add_link which makes a section
of a page clickable, and clicking takes the viewer to a nominated
destination in the document.

Signed-off-by: Paul McGougan <paul@plmservices.com.au>